### PR TITLE
Add repo.actions and repo.packages unit

### DIFF
--- a/gitea/resource_gitea_team.go
+++ b/gitea/resource_gitea_team.go
@@ -78,6 +78,9 @@ func resourceTeamCreate(d *schema.ResourceData, meta interface{}) (err error) {
 	if strings.Contains(d.Get(TeamUnits).(string), "repo.actions") {
 		units = append(units, gitea.RepoUnitActions)
 	}
+	if strings.Contains(d.Get(TeamUnits).(string), "repo.packages") {
+		units = append(units, gitea.RepoUnitPackages)
+	}
 
 	includeAllRepos := d.Get(TeamIncludeAllReposFlag).(bool)
 
@@ -158,6 +161,9 @@ func resourceTeamUpdate(d *schema.ResourceData, meta interface{}) (err error) {
 	}
 	if strings.Contains(d.Get(TeamUnits).(string), "repo.actions") {
 		units = append(units, gitea.RepoUnitActions)
+	}
+	if strings.Contains(d.Get(TeamUnits).(string), "repo.packages") {
+		units = append(units, gitea.RepoUnitPackages)
 	}
 
 	opts := gitea.EditTeamOption{
@@ -283,9 +289,9 @@ func resourceGiteaTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: false,
 				Optional: true,
-				Default:  "[repo.code, repo.issues, repo.ext_issues, repo.wiki, repo.pulls, repo.releases, repo.projects, repo.ext_wiki, repo.actions]",
+				Default:  "[repo.code, repo.issues, repo.ext_issues, repo.wiki, repo.pulls, repo.releases, repo.projects, repo.ext_wiki, repo.actions, repo.packages]",
 				Description: "List of types of Repositories that should be allowed to be created from Team members.\n" +
-					"Can be `repo.code`, `repo.issues`, `repo.ext_issues`, `repo.wiki`, `repo.pulls`, `repo.releases`, `repo.projects`, repo.actions and/or `repo.ext_wiki`",
+					"Can be `repo.code`, `repo.issues`, `repo.ext_issues`, `repo.wiki`, `repo.pulls`, `repo.releases`, `repo.projects`, repo.actions, repo.packages and/or `repo.ext_wiki`",
 			},
 			"repositories": {
 				Type: schema.TypeList,

--- a/gitea/resource_gitea_team.go
+++ b/gitea/resource_gitea_team.go
@@ -75,6 +75,9 @@ func resourceTeamCreate(d *schema.ResourceData, meta interface{}) (err error) {
 	if strings.Contains(d.Get(TeamUnits).(string), "repo.projects") {
 		units = append(units, gitea.RepoUnitProjects)
 	}
+	if strings.Contains(d.Get(TeamUnits).(string), "repo.actions") {
+		units = append(units, gitea.RepoUnitActions)
+	}
 
 	includeAllRepos := d.Get(TeamIncludeAllReposFlag).(bool)
 
@@ -152,6 +155,9 @@ func resourceTeamUpdate(d *schema.ResourceData, meta interface{}) (err error) {
 	}
 	if strings.Contains(d.Get(TeamUnits).(string), "repo.projects") {
 		units = append(units, gitea.RepoUnitProjects)
+	}
+	if strings.Contains(d.Get(TeamUnits).(string), "repo.actions") {
+		units = append(units, gitea.RepoUnitActions)
 	}
 
 	opts := gitea.EditTeamOption{
@@ -277,9 +283,9 @@ func resourceGiteaTeam() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: false,
 				Optional: true,
-				Default:  "[repo.code, repo.issues, repo.ext_issues, repo.wiki, repo.pulls, repo.releases, repo.projects, repo.ext_wiki]",
+				Default:  "[repo.code, repo.issues, repo.ext_issues, repo.wiki, repo.pulls, repo.releases, repo.projects, repo.ext_wiki, repo.actions]",
 				Description: "List of types of Repositories that should be allowed to be created from Team members.\n" +
-					"Can be `repo.code`, `repo.issues`, `repo.ext_issues`, `repo.wiki`, `repo.pulls`, `repo.releases`, `repo.projects` and/or `repo.ext_wiki`",
+					"Can be `repo.code`, `repo.issues`, `repo.ext_issues`, `repo.wiki`, `repo.pulls`, `repo.releases`, `repo.projects`, repo.actions and/or `repo.ext_wiki`",
 			},
 			"repositories": {
 				Type: schema.TypeList,


### PR DESCRIPTION
Adding repo actions and packages unit.

Off topic but just gonna ask because this is blocking us a bit. Is there a reason that branches are not supported in the provider? And also if i were to contribute how would you want them reflected?

- separate resource for branch
- object structure for creating branches inside repository resource
- both?

